### PR TITLE
ci: tidy workflows (drop explanatory comments, collapse single-command run blocks)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,10 +100,6 @@ jobs:
       - name: Generate manifests and CRDs
         run: mise run helm-crds
 
-      # Pin the chart's image to the exact digest the build just published, so the
-      # released chart references an immutable image (not a floating tag). The digest
-      # is the manifest-list (index) digest from docker/github-builder; fail closed
-      # rather than ship a chart that silently falls back to the tag.
       - name: Pin the released image digest into the chart
         env:
           DIGEST: ${{ needs.release.outputs.digest }}
@@ -112,10 +108,7 @@ jobs:
           yq -i '.image.digest = strenv(DIGEST)' charts/litellm-operator/values.yaml
 
       - name: Package Helm chart
-        run: |
-          helm package charts/litellm-operator \
-            --version "${VERSION}" \
-            --app-version "${VERSION}"
+        run: helm package charts/litellm-operator --version "${VERSION}" --app-version "${VERSION}"
 
       - name: Log in to Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -125,9 +118,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Helm chart to GHCR
-        run: |-
-          helm push "litellm-operator-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+        run: helm push "litellm-operator-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
 
       - name: Sign the published chart with Cosign
-        run: |-
-          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/litellm-operator:${VERSION}"
+        run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/litellm-operator:${VERSION}"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -44,17 +44,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |
-          gh run watch \
-            --repo "${{ github.repository_owner }}/.github" \
-            "${RUN_ID}" \
-            --exit-status
+        run: gh run watch --repo "${{ github.repository_owner }}/.github" "${RUN_ID}" --exit-status
 
       - name: Renovate Output
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |-
-          gh run view \
-            --repo "${{ github.repository_owner }}/.github" \
-            --log "${RUN_ID}"
+        run: gh run view --repo "${{ github.repository_owner }}/.github" --log "${RUN_ID}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,7 +82,7 @@ jobs:
           install_args: --locked
 
       - name: Run helm unit tests
-        run: |-
+        run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
           mise run helm-test
 


### PR DESCRIPTION
Workflow tidy matching [echo#26](https://github.com/home-operations/echo/pull/26) and the e2e-repo rollout — the **comment/format cleanup only** (no e2e parallelization in this PR).

## Changes
- Removed explanatory/rationale comments from the workflows.
- Collapsed single-command multi-line `run:` blocks to one-liners (multi-command blocks left as block scalars).

Functional comments preserved: `# yaml-language-server:`, `# renovate:`, `# zizmor:`.

## Verification
Adversarially reviewed and independently cross-checked: no functional comments removed, YAML valid, and **no `uses:` / `with:` / `env:` / `permissions:` / trigger / logic changes** — comment + run-formatting only. Committed with the pre-commit hooks running (zizmor "No findings", format-yaml clean).
