### PR TITLE
fix(llmkube): trim embedding/rerank endpoint suffixes in api_base

### DIFF
--- a/internal/controller/llmkube_projection.go
+++ b/internal/controller/llmkube_projection.go
@@ -37,8 +37,15 @@ const (
 
 	openAICompatPrefix    = "openai/"
 	chatCompletionsSuffix = "/chat/completions"
+	embeddingsSuffix      = "/embeddings"
+	rerankSuffix          = "/rerank"
 	inferenceReadyPhase   = "Ready"
 )
+
+// llmkubeOperationSuffixes are the endpoint paths LLMKube reports per serving
+// mode (see InferenceServiceSpec.Mode); litellm's openai-compatible provider
+// appends the matching one itself, so each must be trimmed from api_base.
+var llmkubeOperationSuffixes = []string{chatCompletionsSuffix, embeddingsSuffix, rerankSuffix}
 
 // projectInferenceService renders the LiteLLMModel that mirrors a Ready LLMKube
 // InferenceService. It is a pure function: no client calls, no ownership wiring
@@ -114,12 +121,18 @@ func llmkubeModelMode(isvc *inferencev1alpha1.InferenceService) string {
 }
 
 // llmkubeAPIBase turns an InferenceService status endpoint into a litellm
-// api_base. LLMKube reports the full chat URL (…/v1/chat/completions); litellm's
-// openai provider wants the server root (…/v1) and appends /chat/completions
-// itself, so the suffix is trimmed. A non-standard path is passed through
-// unchanged.
+// api_base. LLMKube reports the full operation URL (…/v1/chat/completions,
+// …/v1/embeddings, or …/v1/rerank depending on serving mode); litellm's openai
+// provider wants the server root (…/v1) and appends the operation path itself,
+// so whichever suffix matches is trimmed. A non-standard path is passed
+// through unchanged.
 func llmkubeAPIBase(endpoint string) string {
-	return strings.TrimSuffix(endpoint, chatCompletionsSuffix)
+	for _, suffix := range llmkubeOperationSuffixes {
+		if trimmed := strings.TrimSuffix(endpoint, suffix); trimmed != endpoint {
+			return trimmed
+		}
+	}
+	return endpoint
 }
 
 // projectModelInfo fills only the capability fields LLMKube can report

--- a/internal/controller/llmkube_projection_test.go
+++ b/internal/controller/llmkube_projection_test.go
@@ -9,7 +9,10 @@ import (
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
 
-const chatEndpoint = "http://h:8080/v1/chat/completions"
+const (
+	chatEndpoint   = "http://h:8080/v1/chat/completions"
+	trimmedAPIBase = "http://h:8080/v1"
+)
 
 func readyISVC(name, modelRef, endpoint string) *inferencev1alpha1.InferenceService {
 	isvc := &inferencev1alpha1.InferenceService{}
@@ -112,7 +115,9 @@ func TestLLMKubeModelMode(t *testing.T) {
 }
 
 func TestProjectInferenceService_EmbeddingMode(t *testing.T) {
-	isvc := readyISVC("embed", "embed-ref", chatEndpoint)
+	// LLMKube reports the endpoint at the operation-specific path for
+	// embedding services, not the chat-completions default.
+	isvc := readyISVC("embed", "embed-ref", "http://embed.ai.svc.cluster.local:8080/v1/embeddings")
 	isvc.Spec.ExtraArgs = []string{"--embedding", "--pooling", "last"}
 
 	got := projectInferenceService(isvc, nil)
@@ -120,6 +125,8 @@ func TestProjectInferenceService_EmbeddingMode(t *testing.T) {
 	require.NotNil(t, got.Spec.Info)
 	assert.Equal(t, "embedding", got.Spec.Info.Mode)
 	assert.Nil(t, got.Spec.Info.MaxInputTokens, "no Model means no context length, but mode still sets info")
+	assert.Equal(t, "http://embed.ai.svc.cluster.local:8080/v1", got.Spec.Params.APIBase,
+		"the /embeddings suffix must be trimmed too, or litellm double-appends it")
 }
 
 func TestLLMKubeAPIBase(t *testing.T) {
@@ -128,7 +135,9 @@ func TestLLMKubeAPIBase(t *testing.T) {
 		endpoint string
 		want     string
 	}{
-		{"standard chat path", chatEndpoint, "http://h:8080/v1"},
+		{"standard chat path", chatEndpoint, trimmedAPIBase},
+		{"embedding path", "http://h:8080/v1/embeddings", trimmedAPIBase},
+		{"rerank path", "http://h:8080/v1/rerank", trimmedAPIBase},
 		{"non-standard path passes through", "http://h:8080/custom", "http://h:8080/custom"},
 		{"empty endpoint", "", ""},
 	}


### PR DESCRIPTION
## Summary

`llmkubeAPIBase` only strips the `/chat/completions` suffix from an `InferenceService`'s reported endpoint. LLMKube's own API doc (`InferenceServiceSpec.Mode`) states the endpoint path convention is `/v1/embeddings` for embedding mode and `/v1/rerank` for rerank mode, not just `/v1/chat/completions`.

For an embedding or rerank service, the endpoint therefore falls into the "non-standard path passes through unchanged" branch, so `api_base` keeps the full operation path (e.g. `.../v1/embeddings`). litellm's openai-compatible provider then appends its own operation suffix on top of `api_base`, producing a malformed request like `.../v1/embeddings/embeddings` (404).

The existing `TestProjectInferenceService_EmbeddingMode` test didn't catch this because it exercised the embedding case with a `chatEndpoint` fixture (`.../v1/chat/completions`) instead of a realistic embedding endpoint.

## Changes

- `llmkubeAPIBase` now trims whichever of the three known operation suffixes (`/chat/completions`, `/embeddings`, `/rerank`) matches, instead of only the chat one.
- Added `embedding path` / `rerank path` cases to `TestLLMKubeAPIBase`.
- Fixed `TestProjectInferenceService_EmbeddingMode` to use a real `/v1/embeddings` endpoint and assert the resulting `APIBase`, so this regresses loudly if it breaks again.

## Test plan

- [x] `go test ./internal/controller/...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/controller/...` — 0 issues
- [x] `go build ./...` succeeds