### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/charts/litellm-operator/Chart.yaml
+++ b/charts/litellm-operator/Chart.yaml
@@ -4,8 +4,8 @@ name: litellm-operator
 description: A Kubernetes operator that renders LiteLLM proxy config from CRDs
 type: application
 kubeVersion: ">=1.25.0-0"
-version: 0.0.0
-appVersion: "0.0.0"
+version: 0.0.9 # x-release-please-version
+appVersion: "0.0.9" # x-release-please-version
 home: https://github.com/home-operations/litellm-operator
 sources:
   - https://github.com/home-operations/litellm-operator

--- a/charts/litellm-operator/README.md
+++ b/charts/litellm-operator/README.md
@@ -2,7 +2,9 @@
 
 A Kubernetes operator that renders LiteLLM proxy config from CRDs
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.0.9&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.0.9&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 ## Installing
 

--- a/charts/litellm-operator/README.md.gotmpl
+++ b/charts/litellm-operator/README.md.gotmpl
@@ -2,7 +2,16 @@
 
 {{ template "chart.description" . }}
 
-{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+{{- /* Hand-rolled badges instead of the helm-docs badge templates so release-please
+can stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 ## Installing
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/litellm-operator/Chart.yaml" },
+        "charts/litellm-operator/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Ports home-operations/tuppr#414 + home-operations/tuppr#415 to this repo.

## Problem

`charts/litellm-operator/Chart.yaml` carried a `0.0.0` placeholder and only got a
real version at package time (`helm package --version/--app-version` in the
release workflow). The committed chart metadata and the generated README badges
were therefore permanently stale, and `helm template`/`helm install` straight from
a checkout produced `ghcr.io/home-operations/litellm-operator:0.0.0`.

## Change

- `Chart.yaml`: `version`/`appVersion` now hold the current released version
  (`0.0.9`, from `.release-please-manifest.json`) with `# x-release-please-version`
  annotations. The release workflow still re-stamps at package time; this just
  keeps the repo copy from going stale.
- `release-please-config.json`: `extra-files` stamps `Chart.yaml` and the
  generated chart `README.md` on every release.
- `README.md.gotmpl`: the version/appVersion badges are hand-rolled instead of
  helm-docs' badge templates, and the README is regenerated.

### Why the typed `generic` updater

`extra-files` entries are given as:

```json
"extra-files": [
  { "type": "generic", "path": "charts/litellm-operator/Chart.yaml" },
  "charts/litellm-operator/README.md"
]
```

A plain string path ending in `.yaml` makes release-please select its YAML
updater, which re-serializes the document: every comment (including the
`x-release-please-version` annotations themselves) is stripped and `appVersion`
is never stamped. The typed `generic` form does a line-oriented replacement and
preserves the file as written. `README.md` needs no type: `.md` already maps to
the generic updater.

### Why hand-rolled badges

The generic updater replaces only the first semver on an annotated line, and it
would swallow a `-color` suffix as a prerelease. So each version badge uses the
shields `static/v1` query form (version followed by `&`), keeps the version out
of its alt text, and carries its own annotation on its own line. The `Type` badge
keeps the plain `badge/` form since it has no version to stamp.

### Chart tests

No test changes were needed: `tests/deployment_test.yaml` already asserts the
default image by shape (`matchRegex` on the `ghcr.io/home-operations/litellm-operator:`
prefix) rather than against a hardcoded version.

## Verification

All run locally against this branch:

| Gate | Result |
| --- | --- |
| `mise run helm-lint` | pass (1 chart linted, 0 failed; only the pre-existing "icon is recommended" INFO) |
| `mise run helm-test` | pass (2 suites, 8 tests) |
| helm-docs + helm-schema regeneration then `git diff --exit-code` (the `helm-docs-check` gate) | clean, no drift |
| `oxfmt` on the changed YAML/JSON | no reformatting |
| `helm template charts/litellm-operator` | renders `image: ghcr.io/home-operations/litellm-operator:0.0.9` and `app.kubernetes.io/version: "0.0.9"` (was `0.0.0`) |

Note for reviewers reproducing the docs gate locally: a stale
`~/.go/bin/helm-docs` can shadow the mise-pinned `helm-docs` 1.14.2 even under
`mise run`, and that build omits the "Autogenerated from chart metadata" footer,
which shows up as spurious README drift. The committed README here is the output
of the pinned 1.14.2 binary, matching CI.
