### PR TITLE
ci: skip release-please version-bump PRs in checks

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,17 +3,6 @@
 name: E2E
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - .mise/**
-      - charts/**
-      - test/**
-      - Dockerfile
-      - go.mod
-      - go.sum
-      - "**.go"
   pull_request:
     branches:
       - main
@@ -36,6 +25,9 @@ permissions:
 
 jobs:
   e2e:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: E2E (Kind)
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   golangci-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Go Lint
     runs-on: ubuntu-24.04
     permissions:
@@ -62,6 +65,9 @@ jobs:
         run: mise run lint
 
   helm-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Helm Lint
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,9 @@ env:
 
 jobs:
   test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Go Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -67,6 +70,9 @@ jobs:
         run: mise run test-integration
 
   helm-test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Helm Unit Tests
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Two changes, part of an org-wide CI conformity / minutes pass.

**1. Skip only genuine release-please PRs**, using a signal a contributor can't forge:

```yaml
if: >-
  ${{ !(startsWith(github.head_ref, 'release-please--')
  && github.event.pull_request.head.repo.full_name == github.repository) }}
```

`head_ref` alone (the PR's source branch name) is settable by anyone, including from a fork, so a `release-please--*` branch could skip every check. Requiring the PR head repo to be this repo means fork PRs - the realistic path for outside contributors - always run the full suite.

**2. Run e2e on pull requests only.** Dropped the `push: main` trigger: a merged PR already ran e2e, so the post-merge run was redundant. e2e now runs on `pull_request` and `workflow_dispatch`.
