### PR TITLE
ci: wire govulncheck into mise and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,6 +146,29 @@ jobs:
       - name: Running Integration Tests
         run: mise run test-integration
 
+  go-vulncheck:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
+    name: Go Vulncheck
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Run govulncheck
+        run: mise run vulncheck
+
   helm-lint:
     if: >-
       ${{ !(startsWith(github.head_ref, 'release-please--')
@@ -235,6 +258,7 @@ jobs:
       - go-e2e
       - go-lint
       - go-test
+      - go-vulncheck
       - helm-lint
       - helm-unittest
       - workflow-lint

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,7 @@
 [tools]
 actionlint = "1.7.12"
 go = "1.26.5"
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.6.0"
 golangci-lint = "2.12.2"
 helm = "4.2.3"
 cosign = "3.1.2"
@@ -31,6 +32,10 @@ run = "go fmt ./..."
 [tasks.vet]
 description = "Run go vet against code"
 run = "go vet ./..."
+
+[tasks.vulncheck]
+description = "Scan for known vulnerabilities with govulncheck"
+run = "govulncheck ./..."
 
 [tasks.lint]
 description = "Run golangci-lint"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -79,6 +79,10 @@ url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
 checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
 url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
 
+[[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
+version = "1.6.0"
+backend = "go:golang.org/x/vuln/cmd/govulncheck"
+
 [[tools.golangci-lint]]
 version = "2.12.2"
 backend = "aqua:golangci/golangci-lint"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,8 @@ assuming.
 
 ## Security
 
-`govulncheck ./...` (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
-isn't wired into CI anywhere in the fleet yet. Run it before cutting a
-release regardless, and consider proposing it as a `mise run` task / CI job
-here.
+`govulncheck ./...` runs in CI as the `Go Vulncheck` job, via `mise run
+vulncheck` with the tool version pinned in `.mise/config.toml`. Run the
+same task locally before cutting a release; a new advisory that fails the
+job is an action item (upgrade the module or the Go toolchain), not noise
+to suppress.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,10 @@ timeout`), which is what drives release-please's version bumps. Individual
   a comment: that belongs in the PR description and rots as the code moves
   on.
 - **Go 1.26.** Check `go.mod`'s `go` directive and `.mise/config.toml`'s
-  `tools.go` for the exact pinned versions before assuming they match:
-  Renovate bumps them independently, so a patch-version gap between the two
-  is normal, not a bug to "fix" reflexively. When a newer construct is
+  `tools.go` for the exact pinned versions. Renovate bumps them together
+  in one grouped Go-toolchain PR, patch releases included, so the two
+  should match; a lingering gap means a toolchain PR hasn't merged yet
+  (or something is off) and is worth flagging, not routine drift. When a newer construct is
   genuinely more idiomatic, use it: Go 1.26 added `errors.AsType[T](err)`, a
   generic type-safe replacement for the `var t *T; errors.As(err, &t)`
   two-step; prefer it in new code. `go fix` (rebuilt in 1.26 as a


### PR DESCRIPTION
Implements the standing note in AGENTS.md's Security section:

- Pins govulncheck in `.mise/config.toml` via the go backend (`go:golang.org/x/vuln/cmd/govulncheck` 1.6.0) and adds a `vulncheck` task running `govulncheck ./...`.
- Runs it in CI as a `Go Vulncheck` job (same shape and release-please guard as the other Go jobs) wired into the `Build Success` fan-in, so a new advisory blocks the merge queue.
- Updates AGENTS.md's Security section to describe the wired-up state instead of the "not wired into CI yet" note.

`mise run vulncheck` passes locally on this repo's current main.