### PR TITLE
fix: drop UPX compression, packed binaries segfault (upx/upx#18902)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ ARG TARGETARCH
 ARG VERSION=dev
 ARG REVISION=dev
 
-# upx (build stage only) compresses the final binary to shrink the image.
-RUN apk add --no-cache upx
-
 WORKDIR /workspace
 # Download deps in their own layer so source changes don't invalidate the cache.
 COPY go.mod go.mod
@@ -23,8 +20,6 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${REVISION}" \
     -o manager cmd/main.go
-
-RUN upx --best --lzma manager
 
 # https://github.com/GoogleContainerTools/distroless
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
## Overview

Removes UPX compression from the container image build, following home-operations/flate#935.

UPX has an unfixed stub bug ([upx/upx#18902](https://github.com/upx/upx/issues/18902), [discussion #958](https://github.com/upx/upx/discussions/958)) that segfaults packed binaries depending on the size of the process environment. The stub's handoff in `amd64-linux.elf-fold.S` lands one qword high when the environment is large, so the jump target is an `envp` string pointer and the process faults on NX before the Go runtime exists to report anything: exit 139, no stdout, no stderr, no traceback. It depends on argv/envp layout rather than the machine, so it presents as flaky, and adding or removing a single environment variable flips it.

`upx --best --lzma` was a fleet convention, so every UPX-packed Go binary in the org is exposed; flate is just where it surfaced.

## Changes

- Dockerfile: drop the `apk add upx` and `upx --best --lzma` steps from the build stage.

## Notes

- The Go build itself is untouched; this only removes the post-build packing step.
- Image/binary size will grow (flate went from 15.7 MB packed to 73.9 MB unpacked). Dropping only `--lzma` would not help, the defect is in the stub's environment handling, not the compressor.
